### PR TITLE
feat: tournament logic to play battles

### DIFF
--- a/contracts/interfaces/itournament.cairo
+++ b/contracts/interfaces/itournament.cairo
@@ -8,10 +8,10 @@ namespace ITournament:
     func start() -> ():
     end
 
-    func open_tournament_registration() -> ():
+    func open_tournament_registrations() -> ():
     end
 
-    func close_tournament_registration() -> ():
+    func close_tournament_registrations() -> ():
     end
 
     func register(ship_address) -> ():
@@ -35,13 +35,22 @@ namespace ITournament:
     func reward_total_amount() -> (res: Uint256):
     end
 
-    func is_tournament_open() -> (res: felt):
+    func are_tournament_registrations_open() -> (res: felt):
     end
 
     func ships_per_battle() -> (res: felt):
     end
 
     func max_ships_per_tournament() -> (res: felt):
+    end
+
+    func grid_size() -> (res : felt):
+    end
+
+    func turn_count() -> (res : felt):
+    end
+
+    func max_dust() -> (res : felt):
     end
 
     func player_count() -> (res: felt):
@@ -53,5 +62,6 @@ namespace ITournament:
     func ship_player(ship_address: felt) -> (res: felt):
     end
     
-
+    func played_battle_count() -> (res : felt):
+    end
 end

--- a/contracts/test/fake_space.cairo
+++ b/contracts/test/fake_space.cairo
@@ -1,0 +1,14 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin, BitwiseBuiltin
+from starkware.cairo.common.math import (assert_le)
+from contracts.models.common import ShipInit
+
+@external
+func play_game{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        rand_contract_address : felt, size : felt, turn_count : felt, max_dust : felt,
+        ships_len : felt, ships : ShipInit*) -> ():
+    assert_le(ships_len, 2)
+    assert_le(1, ships_len)
+    return ()
+end

--- a/contracts/tournament/Tournament.cairo
+++ b/contracts/tournament/Tournament.cairo
@@ -5,9 +5,12 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.bool import (TRUE, FALSE)
-from starkware.cairo.common.math import (assert_lt, assert_nn)
+from starkware.cairo.common.math import (assert_lt, assert_nn, assert_not_zero)
+from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.uint256 import (Uint256, uint256_le)
 from starkware.starknet.common.syscalls import (get_contract_address, get_caller_address)
+from starkware.cairo.common.math import unsigned_div_rem
+from starkware.cairo.common.alloc import alloc
 
 # OpenZeppeling dependencies
 from openzeppelin.access.ownable import (Ownable_initializer, Ownable_only_owner)
@@ -15,7 +18,7 @@ from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
 from openzeppelin.token.erc721.interfaces.IERC721 import IERC721
 
 from contracts.interfaces.ispace import ISpace
-
+from contracts.models.common import ShipInit, Vector2
 
 # ------------
 # STORAGE VARS
@@ -46,9 +49,14 @@ end
 func rand_contract_address_() -> (res : felt):
 end
 
-# Whether or not registration are open
+# Space contract address
 @storage_var
-func is_tournament_open_() -> (res : felt):
+func space_contract_address_() -> (res : felt):
+end
+
+# Whether or not registrations are open
+@storage_var
+func are_tournament_registrations_open_() -> (res : felt):
 end
 
 # Number of ships per battle
@@ -59,6 +67,21 @@ end
 # Number of ships per tournament
 @storage_var
 func max_ships_per_tournament_() -> (res : felt):
+end
+
+# Size of the grid
+@storage_var
+func grid_size_() -> (res : felt):
+end
+
+# Turn count per battle
+@storage_var
+func turn_count_() -> (res : felt):
+end
+
+# Max dust in the grid at a given time
+@storage_var
+func max_dust_() -> (res : felt):
 end
 
 # Number of players
@@ -76,10 +99,29 @@ end
 func ship_player_(ship_address: felt) -> (res : felt):
 end
 
+# Ship array
+@storage_var
+func ships_(index: felt) -> (ship_address : felt):
+end
+
+# Array of playing ships
+@storage_var
+func playing_ships_(index: felt) -> (ship_address : felt):
+end
+@storage_var
+func playing_ship_count_() -> (res : felt):
+end
+
 # Player scores
 @storage_var
 func player_score_(player_address: felt) -> (res : felt):
 end
+
+# Played battle count
+@storage_var
+func played_battle_count_() -> (res : felt):
+end
+
 
 # -----
 # VIEWS
@@ -120,10 +162,10 @@ func rand_contract_address{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, ran
 end
 
 @view
-func is_tournament_open{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-) -> (is_tournament_open : felt):
-    let (is_tournament_open) = is_tournament_open_.read()
-    return (is_tournament_open)
+func are_tournament_registrations_open{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+) -> (are_tournament_registrations_open : felt):
+    let (are_tournament_registrations_open) = are_tournament_registrations_open_.read()
+    return (are_tournament_registrations_open)
 end
 
 @view
@@ -149,6 +191,27 @@ func max_ships_per_tournament{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
 ) -> (max_ships_per_tournament : felt):
     let (max_ships_per_tournament) = max_ships_per_tournament_.read()
     return (max_ships_per_tournament)
+end
+
+@view
+func grid_size{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+) -> (grid_size : felt):
+    let (grid_size) = grid_size_.read()
+    return (grid_size)
+end
+
+@view
+func turn_count{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+) -> (turn_count : felt):
+    let (turn_count) = turn_count_.read()
+    return (turn_count)
+end
+
+@view
+func max_dust{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+) -> (max_dust : felt):
+    let (max_dust) = max_dust_.read()
+    return (max_dust)
 end
 
 @view
@@ -182,6 +245,13 @@ func player_score{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_
     return (player_score)
 end
 
+@view
+func played_battle_count{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+) -> (played_battle_count : felt):
+    let (played_battle_count) = played_battle_count_.read()
+    return (played_battle_count)
+end
+
 # -----
 # CONSTRUCTOR
 # -----
@@ -198,8 +268,12 @@ func constructor{
         reward_token_address: felt,
         boarding_pass_token_address: felt,
         rand_contract_address: felt,
+        space_contract_address: felt,
         ships_per_battle: felt,
-        max_ships_per_tournament: felt
+        max_ships_per_tournament: felt,
+        grid_size: felt,
+        turn_count: felt,
+        max_dust: felt
     ):
     Ownable_initializer(owner)
     tournament_id_.write(tournament_id)
@@ -207,8 +281,12 @@ func constructor{
     reward_token_address_.write(reward_token_address)
     boarding_pass_token_address_.write(boarding_pass_token_address)
     rand_contract_address_.write(rand_contract_address)
+    space_contract_address_.write(space_contract_address)
     ships_per_battle_.write(ships_per_battle)
     max_ships_per_tournament_.write(max_ships_per_tournament)
+    grid_size_.write(grid_size)
+    turn_count_.write(turn_count)
+    max_dust_.write(max_dust)
     player_count_.write(0)
     return ()
 end
@@ -217,21 +295,23 @@ end
 # EXTERNAL FUNCTIONS
 # -----
 
-# Open tournament registration
+# Open tournament registrations
 @external
-func open_tournament_registration{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+func open_tournament_registrations{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
 ) -> (success: felt):
-    Ownable_only_owner()
-    _only_tournament_closed()
+    #TODO: add Ownable_only_owner()
+    _only_tournament_registrations_closed()
+    are_tournament_registrations_open_.write(TRUE)
     return (TRUE)
 end
 
-# Close tournament registration
+# Close tournament registrations
 @external
-func close_tournament_registration{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+func close_tournament_registrations{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
 ) -> (success: felt):
-    Ownable_only_owner()
-    _only_tournament_open()
+    #TODO: add Ownable_only_owner()
+    _only_tournament_registrations_open()
+    are_tournament_registrations_open_.write(FALSE)
     return (TRUE)
 end
 
@@ -239,7 +319,11 @@ end
 # Start the tournament
 @external
 func start{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (success: felt):
-    # TODO: implement start function
+    #TODO: add Ownable_only_owner()
+    _only_tournament_registrations_closed()
+    
+    _recursive_start()
+    
     return (TRUE)
 end
 
@@ -250,7 +334,7 @@ func register{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
     ship_address: felt
 ) -> (success: felt):
     alloc_locals
-    _only_tournament_open()
+    _only_tournament_registrations_open()
     let (player_address) = get_caller_address()
     let (boarding_pass_token_address) = boarding_pass_token_address_.read()
     # Check access control with NFT boarding pass
@@ -279,10 +363,14 @@ func register{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
     with_attr error_message("Tournament: ship already registered"):
         assert ship_registered_player = 0
     end
+    player_count_.write(current_player_count + 1)
     # Write player => ship association
     player_ship_.write(player_address, ship_address)
     # Write ship => player association
     ship_player_.write(ship_address, player_address)
+    # Push ship to array of playing ships
+    playing_ships_.write(current_player_count, ship_address)
+    playing_ship_count_.write(current_player_count + 1)
     return (TRUE)
 end
 
@@ -311,20 +399,151 @@ func _decrease_score{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_che
     return ()
 end
 
-func _only_tournament_open{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+func _only_tournament_registrations_open{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
 ):
-    let (is_tournament_open) = is_tournament_open_.read()
+    let (are_tournament_registrations_open) = are_tournament_registrations_open_.read()
     with_attr error_message("Tournament: tournament is open"):
-        assert is_tournament_open = TRUE
+        assert are_tournament_registrations_open = TRUE
     end
     return ()
 end
 
-func _only_tournament_closed{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+func _only_tournament_registrations_closed{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
 ):
-    let (is_tournament_open) = is_tournament_open_.read()
+    let (are_tournament_registrations_open) = are_tournament_registrations_open_.read()
     with_attr error_message("Tournament: tournament is closed"):
-        assert is_tournament_open = FALSE
+        assert are_tournament_registrations_open = FALSE
     end
     return ()
 end
+
+# Recursively plays all battles until there is only one winner
+func _recursive_start{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    let (ship_count) = playing_ship_count_.read()
+    assert_not_zero(ship_count)
+    
+    let (winner_ships_len : felt, winner_ships : felt*) = _play_current_round_battles()
+    assert_not_zero(winner_ships_len)
+
+    if winner_ships_len == 1:
+        # This is the end! We have a single winner!
+        return ()
+    end
+
+    _update_playing_ships_for_next_round(winner_ships_len, winner_ships)
+    _recursive_start()
+    return ()
+end
+
+# Play all battles of the current round
+func _play_current_round_battles{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (winner_ships_len : felt, winner_ships : felt*):
+    alloc_locals
+    let (winner_ships : felt*) = alloc()
+    let (winner_ships_len) = _recursive_play_current_round_battles(0, 0, winner_ships)
+    return (winner_ships_len, winner_ships)
+end
+
+func _recursive_play_current_round_battles{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(ship_index : felt, winner_ships_len : felt, winner_ships : felt*) -> (new_winner_ships_len : felt):
+    alloc_locals
+
+    let (local ships_len : felt, ships : ShipInit*) = _build_battle_ship_array(ship_index)
+    if ships_len == 0:
+        # No more ship in competition. The round is finished.
+        return (winner_ships_len)
+    end
+
+    let (winner_ship) = _play_next_battle(ships_len, ships)
+
+    # Add winner ship to the list of winners of this round
+    assert winner_ships[winner_ships_len] = winner_ship
+    
+    return _recursive_play_current_round_battles(ship_index + ships_len, winner_ships_len + 1, winner_ships)
+end
+
+# Play the battle entirely
+func _play_next_battle{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(ships_len : felt, ships : ShipInit*) -> (winner_ship : felt):
+    alloc_locals
+    let (space_contract) = space_contract_address_.read()
+    let (rand_contract) = rand_contract_address_.read()
+    let (grid_size) = grid_size_.read()
+    let (turn_count) = turn_count_.read()
+    let (max_dust) = max_dust_.read()
+
+    ISpace.play_game(space_contract,
+            rand_contract, grid_size, turn_count, max_dust,
+            ships_len, ships)
+    
+    let (played_battle_count) = played_battle_count_.read()
+    played_battle_count_.write(played_battle_count + 1)
+
+    # TODO: get scores
+    # TODO: get winner
+    let winner_ship = ships[0]
+
+    return (winner_ship.address)
+end
+
+# Get the ships that will participate in the next battle
+func _build_battle_ship_array{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(ship_index : felt) -> (
+        ships_len : felt, ships : ShipInit*):
+    alloc_locals
+
+    let (local ships : ShipInit*) = alloc()
+
+    let (ships_len) = _recursive_build_battle_ship_array(ship_index, 0, ships)
+
+    return (ships_len, ships)
+end
+
+func _recursive_build_battle_ship_array{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        ship_index : felt, ships_len : felt, ships : ShipInit*) -> (len : felt):
+    alloc_locals
+    let (ships_per_battle) = ships_per_battle_.read()
+    if ships_len == ships_per_battle:
+        return (ships_len)
+    end
+
+    let (ship_count) = playing_ship_count_.read()
+    if ship_index == ship_count:
+        return (ships_len)
+    end
+
+    let (ship_address : felt) = playing_ships_.read(ship_index)
+    assert_not_zero(ship_address)
+
+    let (initial_position : Vector2) = _get_initial_ship_position(ships_len)
+
+    assert ships[ships_len] = ShipInit(address=ship_address, position=initial_position)
+
+    return _recursive_build_battle_ship_array(ship_index + 1, ships_len + 1, ships)
+end
+
+func _get_initial_ship_position{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(battle_ship_index : felt) -> (
+        initial_position : Vector2):
+    let (grid_size) = grid_size_.read()
+
+    let (y, x) = unsigned_div_rem(battle_ship_index, grid_size)
+
+    return (Vector2(x, y))
+end
+
+# Update the list of ships that will be playing in the next ground
+func _update_playing_ships_for_next_round{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(winner_ships_len : felt, winner_ships : felt*):
+    playing_ship_count_.write(winner_ships_len)
+
+    _recursive_update_playing_ships_for_next_round(0, winner_ships_len, winner_ships)
+    return ()
+end
+
+func _recursive_update_playing_ships_for_next_round{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(index : felt, winner_ships_len : felt, winner_ships : felt*):
+    if winner_ships_len == 0:
+        return ()
+    end
+
+    let ship_address : felt = [winner_ships]
+    playing_ships_.write(index, ship_address)
+
+    _recursive_update_playing_ships_for_next_round(index + 1, winner_ships_len - 1, &winner_ships[1])
+    return ()
+end
+

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -1,0 +1,96 @@
+from typing import List, NamedTuple
+import pytest
+
+from starkware.starknet.testing.starknet import Starknet
+from starkware.starknet.testing.contract import StarknetContract
+from starkware.starknet.public.abi import get_selector_from_name
+
+from fixtures import *
+from deploy import deploy_contract
+from utils import assert_revert, to_uint
+
+ADMIN = get_selector_from_name('admin')
+ANYONE = get_selector_from_name('anyone')
+SPACE_SIZE = 6
+MAX_TURN = 50
+MAX_DUST = 2
+MAX_FELT = 2**251 + 17 * 2**192 + 1
+
+SHIP1 = 100
+SHIP2 = 102
+SHIP3 = 103
+SHIP4 = 104
+PLAYER1 = get_selector_from_name('player1')
+PLAYER2 = get_selector_from_name('player2')
+PLAYER3 = get_selector_from_name('player3')
+PLAYER4 = get_selector_from_name('player4')
+
+# Auxiliary functions
+def str_to_felt(text):
+    b_text = bytes(text, "ascii")
+    return int.from_bytes(b_text, "big")
+def uint(a):
+    return(a, 0)
+
+@pytest.fixture
+async def tournament_factory(starknet: Starknet) -> StarknetContract:
+    
+    name = str_to_felt("OnlyDust")
+    symbol = str_to_felt("ODUST")
+    decimals = 18
+    recipient = ADMIN
+    onlyDust = await deploy_contract(starknet, 'token/OnlyDust.cairo', constructor_calldata=[name, symbol, decimals, 1000000, 0, recipient])
+
+    name = str_to_felt("StarKonquestBoardingPass")
+    symbol = str_to_felt("SKBP")
+    owner = ADMIN
+    starKonquestBoardingPass = await deploy_contract(starknet, 'token/StarKonquestBoardingPass.cairo', constructor_calldata=[name, symbol, owner])
+    await starKonquestBoardingPass.mint(PLAYER1, (1,0)).invoke(caller_address=ADMIN)
+    await starKonquestBoardingPass.mint(PLAYER2, (2,0)).invoke(caller_address=ADMIN)
+    await starKonquestBoardingPass.mint(PLAYER3, (3,0)).invoke(caller_address=ADMIN)
+    await starKonquestBoardingPass.mint(PLAYER4, (4,0)).invoke(caller_address=ADMIN)
+
+    space = await deploy_contract(starknet, 'core/space.cairo')
+    rand = await deploy_contract(starknet, 'core/rand.cairo')
+    space = await deploy_contract(starknet, 'test/fake_space.cairo')
+
+    owner = ADMIN
+    season_id = 1
+    season_name = str_to_felt("StarkNet Hackathon AMS")
+    reward_token_address = onlyDust.contract_address
+    boarding_pass_token_address = starKonquestBoardingPass.contract_address
+    ships_per_battle = 2
+    max_players = 16
+    params = [owner, season_id, season_name, reward_token_address, boarding_pass_token_address, 
+        rand.contract_address, space.contract_address, 
+        ships_per_battle, max_players, 6, 3, 2]
+    tournament = await deploy_contract(starknet, 'tournament/Tournament.cairo', constructor_calldata=params)
+
+    return tournament
+
+@pytest.mark.asyncio
+async def test_tournament_e2e(tournament_factory):
+    tournament = tournament_factory
+
+    execution_info = await tournament.are_tournament_registrations_open().call()
+    assert execution_info.result == (0,)
+
+    await tournament.open_tournament_registrations().invoke(caller_address=ADMIN)
+
+    execution_info = await tournament.are_tournament_registrations_open().call()
+    assert execution_info.result == (1,)
+
+    await tournament.register(SHIP1).invoke(caller_address=PLAYER1)
+    await tournament.register(SHIP2).invoke(caller_address=PLAYER2)
+    await tournament.register(SHIP3).invoke(caller_address=PLAYER3)
+    await tournament.register(SHIP4).invoke(caller_address=PLAYER4)
+
+    await tournament.close_tournament_registrations().invoke(caller_address=ADMIN)
+
+    execution_info = await tournament.are_tournament_registrations_open().call()
+    assert execution_info.result == (0,)
+
+    await tournament.start().invoke(caller_address=ADMIN)
+
+    execution_info = await tournament.played_battle_count().call()
+    assert execution_info.result == (3,) # 2 battles in first round, and 1 final battle

--- a/tests/tournament/test_tournament.cairo
+++ b/tests/tournament/test_tournament.cairo
@@ -9,6 +9,7 @@ from starkware.starknet.common.syscalls import get_contract_address, get_caller_
 const ONLY_DUST_TOKEN_ADDRESS = 0x3fe90a1958bb8468fb1b62970747d8a00c435ef96cda708ae8de3d07f1bb56b
 const BOARDING_TOKEN_ADDRESS = 0x00348f5537be66815eb7de63295fcb5d8b8b2ffe09bb712af4966db7cbb04a95
 const RAND_ADDRESS = 0x00348f5537be66815eb7de63295fcb5d8b8b2ffe09bb712af4966db7cbb04a91
+const SPACE_ADDRESS = 0x00348f5537be66815eb7de63295fcb5d8b8b2ffe09bb712af4966db7cbb04aaa
 
 @external
 func test_tournament{syscall_ptr : felt*, range_check_ptr}():
@@ -16,6 +17,7 @@ func test_tournament{syscall_ptr : felt*, range_check_ptr}():
     tempvar only_dust_token_address = ONLY_DUST_TOKEN_ADDRESS
     tempvar boarding_pass_token_address = BOARDING_TOKEN_ADDRESS
     tempvar rand_address = RAND_ADDRESS
+    tempvar space_address = SPACE_ADDRESS
 
     local tournament_address : felt
     %{ 
@@ -28,31 +30,64 @@ func test_tournament{syscall_ptr : felt*, range_check_ptr}():
                 ids.only_dust_token_address, # ERC20 token address of the reward
                 ids.boarding_pass_token_address, # ERC721 token address for access control
                 ids.rand_address, # Random generator contract address
+                ids.space_address, # Space contract address
                 2, # Ships per battle
-                8  # Maximum Ships per tournament
+                8, # Maximum Ships per tournament
+                5, # grid_size
+                3, # turn_count
+                2, # max_dust
             ]
         ).contract_address 
     %}
     %{ mock_call(ids.only_dust_token_address, "balanceOf", [100, 0]) %}
     let (reward_total_amount) = ITournament.reward_total_amount(tournament_address)
     assert reward_total_amount.low = 100
-    assert reward_total_amount.high = 0
+    assert reward_total_amount.high = 0  
 
-    %{ stop_expecting_revert = expect_revert(error_message="Ownable: caller is not the owner") %}
-    ITournament.open_tournament_registration(tournament_address)
-    %{ stop_expecting_revert() %}   
-
-    # Changes caller address to owner
+    # Start registration
     %{ start_prank(42) %}
-    ITournament.open_tournament_registration(tournament_address)
-    let (is_open) = ITournament.is_tournament_open(tournament_address)
+    let (is_open) = ITournament.are_tournament_registrations_open(tournament_address)
+    assert is_open = FALSE
+
+    ITournament.open_tournament_registrations(tournament_address)
+
+    let (is_open) = ITournament.are_tournament_registrations_open(tournament_address)
     assert is_open = TRUE
     %{ stop_prank() %}
+
 
     # Player 1 registers ship 1
     %{ start_prank(1) %}
     ITournament.register(tournament_address, 1)
     %{ stop_prank() %}
+
+    # Player 2 registers ship 2
+    %{ start_prank(2) %}
+    ITournament.register(tournament_address, 2)
+    %{ stop_prank() %}
+
+    # Player 3 registers ship 3
+    %{ start_prank(3) %}
+    ITournament.register(tournament_address, 3)
+    %{ stop_prank() %}
+
+    # Close registration
+    %{ start_prank(42) %}
+    ITournament.close_tournament_registrations(tournament_address)
+    let (is_open) = ITournament.are_tournament_registrations_open(tournament_address)
+    assert is_open = FALSE
+    %{ stop_prank() %}
+
+    let (played_battle_count) = ITournament.played_battle_count(tournament_address)
+    assert played_battle_count = 0
+
+    # Play the entire game
+    %{ start_prank(42) %}
+    ITournament.start(tournament_address)
+    %{ stop_prank() %}
+
+    let (played_battle_count) = ITournament.played_battle_count(tournament_address)
+    assert played_battle_count = 2
 
     return ()
 end


### PR DESCRIPTION
This PR implements the tournament logic.
- A tournament has several rounds.
- Each round has several battles

The ENTIRE tournament is done in a single transaction (we will want to change that later).

The logic is:
```
tournament is open for registrations
players register their ship
tournament is closed for registrations

until there is only one playing ship remaining, do {
    iterate through the list of playing ships {
        create an array of players for the next battle (this array typically contains 2 players)
        play the battle
        store the winner in a winner_ships array
    }
    update the list of playing ships with the winner_ships array
}

there is only one ship remaining, this is our winner!
```

For now, the test only checks that the right amount of battles have been played: 4 players in a tournament where battles have 2 players should play 3 battles (2 battles in first round + 1 final battle).